### PR TITLE
Add a way to see mari updates

### DIFF
--- a/.github/workflows/mari_sync.yml
+++ b/.github/workflows/mari_sync.yml
@@ -3,7 +3,7 @@ name: Automated Mari Update
 
 on:
   schedule:
-    - cron: '*/10 * * * *'  # Run every 10 minutes
+    - cron: '13 3 * * *'  # Run once a day at 3:13 AM
 
 jobs:
   update:


### PR DESCRIPTION
Adds an action to create a PR to update the original script prompting us to update the modified version.
Because we modify the mari script so heavily we cannot trivially update it automatically so it will require some manual modification. As such I have devised the following workflow

1. Check if an existing automatic PR is open, if it is, end the job.
2. CURL the mantid script repository and save a temporary version of the latest mari script
3. Perform a diff on our original and the latest version. if they are the same, end the job
4. Create a PR assigning us as reviewers

We would then need to make sure our script is still acceptable making whatever changes necessary.

To see the example PRs: https://github.com/interactivereduction/autoreduction-scripts/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Fgithub-actions

Question: Is this the correct url: https://raw.githubusercontent.com/mantidproject/scriptrepository/master/direct_inelastic/MARI/template_mari.py
The script appears to match ours, but is the location Duc is currently updating?
